### PR TITLE
[kotlin compiler][update][fixup] 1.4.0-dev-588

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-508,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-508
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-508,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-508
-kotlinStdlibTestsVersion=1.4.0-dev-508
-testKotlinCompilerVersion=1.4.0-dev-508
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-588,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-588
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-588,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-588
+kotlinStdlibTestsVersion=1.4.0-dev-588
+testKotlinCompilerVersion=1.4.0-dev-588
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 98f5c5aa95a - (tag: build-1.4.0-dev-588) JVM_IR: Preserve annotations on inline class replacement methods. (4 days ago) <Mads Ager>
* e7835fecfc9 - (tag: build-1.4.0-dev-587) JVM_IR: fix a couple of inline class reflection issues. (4 days ago) <Mads Ager>
* 2ebb797e616 - (tag: build-1.4.0-dev-582) JVM_IR: Remove accessor for internal inline class properties. (4 days ago) <Mads Ager>
* d27593aedaa - (tag: build-1.4.0-dev-577) PSI2IR: SAM conversion in method arguments of out-projected Java classes (4 days ago) <Dmitry Petrov>
* a55bce801ed - (tag: build-1.4.0-dev-575) Update year in the license to 2020 (4 days ago) <Alexander Udalov>
* e0b9ffa7801 - Regenerate builtins sources (4 days ago) <Alexander Udalov>
* d73e6c855ba - (tag: build-1.4.0-dev-565) Regenerate FIR tree (5 days ago) <Alexander Udalov>
* 8a4510c21b5 - (tag: build-1.4.0-dev-563) Regenerate tests (5 days ago) <Alexander Udalov>
* a55296db269 - (tag: build-1.4.0-dev-556) Mute flaky GradleKtsImportTest.testCompositeBuild (7 days ago) <Vyacheslav Gerasimov>
* 1b00996c868 - (tag: build-1.4.0-dev-553) Mute failing test-kotlin-version-in-manifest (7 days ago) <Vyacheslav Gerasimov>
* 8054e2960e3 - (tag: build-1.4.0-dev-551) PSI2IR: Post-process return expressions based on expected return type (7 days ago) <Dmitry Petrov>
* 0e4e5ac287c - (tag: build-1.4.0-dev-547) Update nullability assertion tests that use newer Java features (7 days ago) <Dmitry Petrov>
* d6225428240 - (tag: build-1.4.0-dev-536) PSI2IR: Fix delegated members generation (8 days ago) <Dmitry Petrov>
* cc0b231b3b1 - (tag: build-1.4.0-dev-534) Convert SyntheticMethodForAnnotatedPropertyGenTest to a box test (8 days ago) <Alexander Udalov>
* 8f30b25b243 - Minor, fix some codegen tests for language version 1.4 (8 days ago) <Alexander Udalov>
* e2a42446ed0 - Use getter names for $annotations methods in most codegen tests (8 days ago) <Alexander Udalov>
* 330dd789de8 - (tag: build-1.4.0-dev-524) Minor: mute test in FIR+JVM_IR (8 days ago) <Dmitry Petrov>
* c7d39b612cf - (tag: build-1.4.0-dev-521) Simplify adding Kotlin sdk by inlining internals of ProjectSdksModel (8 days ago) <Nikolay Krasko>
* 70067bc9bfe - Better fix for compiler plugin test initialization (8 days ago) <Nikolay Krasko>
* 1715f1a864b - (tag: build-1.4.0-dev-517) [FIR] Refactoring: create use-site scopes via scope provider (8 days ago) <Simon Ogorodnik>
* 5f08fe88a59 - [FIR] Move ScopeSession to fir:tree (8 days ago) <Mikhail Glukhikh>
* 98bf0e278f2 - (origin/rr/pdn_jvmir_vararg) Fix problem with empty vararg of boxed primitives in JVM_IR (8 days ago) <Dmitry Petrov>
* 0667ee97962 - Minor: optimize imports (8 days ago) <Dmitry Petrov>
* 76e7a9ba4ac - Generate instructions as text in case of other exceptions (8 days ago) <Dmitry Petrov>
* 4b6202c9024 - (tag: build-1.4.0-dev-515, tag: build-1.4.0-dev-511) JVM_IR. Support inlining of bound CR (8 days ago) <Mikhael Bogdanov>